### PR TITLE
選択ソートの最適化

### DIFF
--- a/SortP/Sort.py
+++ b/SortP/Sort.py
@@ -19,16 +19,11 @@ def insertion(num):
 def selection(num):
     for i in range(len(num)):
         print(num)
-        min_num = num[i]
-        min_index = i;
-        tmp = num[i]
-        if i < len(num):
-            for j in range(i,len(num)):
-                if min_num > num[j]:
-                    min_num = num[j]
-                    min_index = j
-            num[min_index] = tmp
-            num[i] = min_num
+        min_index = i
+        for j in range(i,len(num)):
+            if num[min_index] > num[j]:
+                min_index = j
+        num[i], num[min_index] = num[min_index], num[i]
     return num
 def shaker(num):
     for i in range(len(num)):


### PR DESCRIPTION
- `i`の範囲チェックを削除
`i`は`range(len(num))`で生成されているので、`i < len(num)`は自明です。

- `tmp`を削除
多重代入を使えば必要ありません。

- `min_num`を削除
配列は番号さえ覚えておけば中身の値はいつでも取れるので、値を保持しておく必要はありません。
大雑把な考えとして、普通の変数へのアクセスには1ステップ、配列の要素へのアクセスには3ステップ(配列の先頭を取得→添字を取得→指定要素を取得)を必要とします。
したがって、考えなしに置き換えるとステップ数が増えることもありますが、今回は`min_num`を削除して処理が少なくなったことと差し引きで総ステップ数は減少しています。